### PR TITLE
Fix REASON_* constant compatibility

### DIFF
--- a/addon/globalPlugins/audiothemes/unspoken/__init__.py
+++ b/addon/globalPlugins/audiothemes/unspoken/__init__.py
@@ -13,6 +13,9 @@ import speech
 import sayAllHandler
 
 
+# for compatibility
+REASON_QUERY = NVDAObjects.controlTypes.OutputReason.QUERY if hasattr(NVDAObjects.controlTypes, "OutputReason") else NVDAObjects.controlTypes.REASON_QUERY
+
 # this is a hack.
 # Normally, we would modify Libaudioverse to know about Unspoken and NVDA.
 # But if Windows sees a DLL is already loaded, it doesn't reload it.
@@ -84,7 +87,7 @@ class UnspokenPlayer:
         return True
 
     def _hook_getPropertiesSpeech(
-        self, reason=NVDAObjects.controlTypes.REASON_QUERY, *args, **kwargs
+        self, reason=REASON_QUERY, *args, **kwargs
     ):
         role = kwargs.get("role", None)
         if role:

--- a/buildVars.py
+++ b/buildVars.py
@@ -32,7 +32,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion" : "2019.3",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2019.3",
+	"addon_lastTestedNVDAVersion" : "2021.1",
 	# Add-on update channel (default is None, denoting stable releases, and for development releases, use "dev"; do not change unless you know what you are doing)
 	"addon_updateChannel" : None,
 }


### PR DESCRIPTION
Hi,
I introduced a bridge-constant in unspoken/__init__.py, to guarantee compatibility with old and new version of NVDA, after the breaking changes in incoming 2021.1.
Updated lastTestedNVDAVersion accordingly.
I'm avoiding to distribute the modified version, even if some users are requesting it. So I'll be happy if you release a new updated version :)
This is my first pr, I hope I have done all without errors.